### PR TITLE
fix: strict default csp

### DIFF
--- a/app/view/index.html
+++ b/app/view/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; img-src * data: blob: 'unsafe-inline';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval';" />
     <base target="_blank">
   </head>
   <body>


### PR DESCRIPTION
A script could encode data in a URL and then load an image with the URL that encodes data - thereby exposing notebook data. This makes it so no external urls are allowed.